### PR TITLE
treewide: fix typo s/kmemdup_user/memdup_user/

### DIFF
--- a/check_allocation_funcs.c
+++ b/check_allocation_funcs.c
@@ -45,7 +45,7 @@ static const char *allocation_funcs[] = {
 	"devm_kmalloc_array",
 	"sock_kmalloc",
 	"kmemdup",
-	"kmemdup_user",
+	"memdup_user",
 	"dma_alloc_attrs",
 	"pci_alloc_consistent",
 	"pci_alloc_coherent",

--- a/smatch_buf_size.c
+++ b/smatch_buf_size.c
@@ -1009,7 +1009,7 @@ void register_buf_size(int id)
 		add_allocation_function("devm_kmalloc_array", &match_calloc, 1);
 		add_allocation_function("sock_kmalloc", &match_alloc, 1);
 		add_allocation_function("kmemdup", &match_alloc, 1);
-		add_allocation_function("kmemdup_user", &match_alloc, 1);
+		add_allocation_function("memdup_user", &match_alloc, 1);
 		add_allocation_function("dma_alloc_attrs", &match_alloc, 1);
 		add_allocation_function("pci_alloc_consistent", &match_alloc, 1);
 		add_allocation_function("pci_alloc_coherent", &match_alloc, 1);

--- a/smatch_constraints_required.c
+++ b/smatch_constraints_required.c
@@ -40,7 +40,7 @@ static struct allocator kernel_allocator_table[] = {
 	{"vzalloc", 0},
 	{"sock_kmalloc", 1},
 	{"kmemdup", 1},
-	{"kmemdup_user", 1},
+	{"memdup_user", 1},
 	{"dma_alloc_attrs", 1},
 	{"pci_alloc_consistent", 1},
 	{"pci_alloc_coherent", 1},
@@ -482,7 +482,7 @@ void register_constraints_required(int id)
 		add_allocation_function("vzalloc", &match_alloc, 0);
 		add_allocation_function("sock_kmalloc", &match_alloc, 1);
 		add_allocation_function("kmemdup", &match_alloc, 1);
-		add_allocation_function("kmemdup_user", &match_alloc, 1);
+		add_allocation_function("memdup_user", &match_alloc, 1);
 		add_allocation_function("dma_alloc_attrs", &match_alloc, 1);
 		add_allocation_function("pci_alloc_consistent", &match_alloc, 1);
 		add_allocation_function("pci_alloc_coherent", &match_alloc, 1);

--- a/smatch_fresh_alloc.c
+++ b/smatch_fresh_alloc.c
@@ -44,7 +44,7 @@ struct alloc_info kernel_allocation_funcs[] = {
 	{"kmalloc_array", 0, 1},
 	{"sock_kmalloc", 1},
 	{"kmemdup", 1},
-	{"kmemdup_user", 1},
+	{"memdup_user", 1},
 	{"dma_alloc_attrs", 1},
 	{"pci_alloc_consistent", 1},
 	{"pci_alloc_coherent", 1},


### PR DESCRIPTION
Hi,

there is no kmemdup_user in the kernel (there is only memdup_user).

Thanks,
Denis