### PR TITLE
flow: set prev_stream

### DIFF
--- a/smatch_flow.c
+++ b/smatch_flow.c
@@ -166,6 +166,7 @@ static void set_position(struct position pos)
 	if (pos.stream == prev_stream)
 		return;
 
+	prev_stream = pos.stream;
 	filename = stream_name(pos.stream);
 
 	free(full_filename);


### PR DESCRIPTION
Make sure to set prev_stream in order to make use of the full_filename caching.

A little background:

We use smatch to lint illumos builds. While inspecting the system during a build I noticed an hundreds of millions of `getcwd` and `pathconf` system calls. I traced them back to `set_position` and noticed that it looks like it is meant to cache the `full_filename` by checking `prev_stream` -- but it never sets `prev_stream`.

Thank you for your work on smatch.