### PR TITLE
shell scripts: stricter error handling

### DIFF
--- a/smatch_data/db/apply_return_fixes.sh
+++ b/smatch_data/db/apply_return_fixes.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if echo $1 | grep -q '^-p' ; then
     PROJ=$(echo $1 | cut -d = -f 2)
     shift

--- a/smatch_data/db/build_early_index.sh
+++ b/smatch_data/db/build_early_index.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 db_file=$1
 
 

--- a/smatch_data/db/build_late_index.sh
+++ b/smatch_data/db/build_late_index.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 db_file=$1
 
 

--- a/smatch_data/db/create_db.sh
+++ b/smatch_data/db/create_db.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if echo $1 | grep -q '^-p' ; then
     PROJ=$(echo $1 | cut -d = -f 2)
     shift

--- a/smatch_data/db/delete_too_common_fn_ptr.sh
+++ b/smatch_data/db/delete_too_common_fn_ptr.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 db_file=$1
 
 IFS="|"

--- a/smatch_data/db/fixup_all.sh
+++ b/smatch_data/db/fixup_all.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 db_file=$1
 cat << EOF | sqlite3 $db_file
 

--- a/smatch_data/db/fixup_kernel.sh
+++ b/smatch_data/db/fixup_kernel.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 db_file=$1
 bin_dir=$(dirname $0)
 

--- a/smatch_scripts/build_kernel_data.sh
+++ b/smatch_scripts/build_kernel_data.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 PROJECT=kernel
 
 function usage {

--- a/smatch_scripts/kchecker
+++ b/smatch_scripts/kchecker
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 function usage {
     echo "Usage:  $0 [--sparse][--valgrind][--debug] path/to/file.c"
     exit 1

--- a/smatch_scripts/test_kernel.sh
+++ b/smatch_scripts/test_kernel.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 NR_CPU=$(cat /proc/cpuinfo | grep ^processor | wc -l)
 TARGET="bzImage modules"
 WLOG="smatch_warns.txt"


### PR DESCRIPTION
Various shell scripts exit with return code zero even their subprocesses fail (for example, due to missing libraries).

Use set -e to exit immediately with an error code if a subprocess fails.