### PR TITLE
Make smatch easier to use with generic projects

### DIFF
--- a/smatch_scripts/build_generic_data.sh
+++ b/smatch_scripts/build_generic_data.sh
@@ -62,7 +62,7 @@ if [[ ! -z $O ]] ; then
 	KERNEL_O="O=$O"
 fi
 
-make $KERNEL_ARCH $KERNEL_CROSS_COMPILE $KERNEL_O -j${NR_CPU} CHECK="$BIN_DIR/smatch --call-tree --info --spammy --file-output" $TARGET
+make $KERNEL_ARCH $KERNEL_CROSS_COMPILE $KERNEL_O -j${NR_CPU} CC=$BIN_DIR/cgcc CHECK="$BIN_DIR/smatch --call-tree --info --spammy --file-output" $TARGET
 
 find -name \*.c.smatch -exec cat \{\} \; -exec rm \{\} \; > smatch_warns.txt
 


### PR DESCRIPTION
I've been trying to use smatch with Slurm (the HPC batch scheduler) and I realised that these two changes to the build_generic_data.sh and test_generic.sh scripts make it easier to use out of the box for a generic project, viz:

```
wget https://download.schedmd.com/slurm/slurm-24.11.5.tar.bz2 tar xzf slurm-24.11.5.tar.bz2
cd slurm-24.11.5
./configure
/path/to/smatch/smatch_scripts/build_generic_data.sh -p slurm /path/to/smatch/smatch_scripts/test_generic.sh -p slurm
```

Of course you need to remember to create an empty, executable smatch_data/db/fixup_slurm.sh script first!