### PR TITLE
Skip a missing project specific fixup file

### DIFF
--- a/smatch_data/db/create_db.sh
+++ b/smatch_data/db/create_db.sh
@@ -47,7 +47,8 @@ ${bin_dir}/build_late_index.sh $db_file
 
 ${bin_dir}/fixup_all.sh $db_file
 if [ "$PROJ" != "" ] ; then
-    ${bin_dir}/fixup_${PROJ}.sh $db_file
+    # Run the fixup script only if it exists and is executable
+    test -x ${bin_dir}/fixup_${PROJ}.sh && ${bin_dir}/fixup_${PROJ}.sh $db_file
 fi
 
 ${bin_dir}/copy_function_pointers.pl $db_file

--- a/smatch_data/db/reload_partial.sh
+++ b/smatch_data/db/reload_partial.sh
@@ -44,6 +44,7 @@ rm $tmp_file
 
 ${bin_dir}/fixup_all.sh $db_file
 if [ "$PROJ" != "" ] ; then
-    ${bin_dir}/fixup_${PROJ}.sh $db_file
+    # Run the fixup script only if it exists and is executable
+    test -x ${bin_dir}/fixup_${PROJ}.sh && ${bin_dir}/fixup_${PROJ}.sh $db_file
 fi
 


### PR DESCRIPTION
The create_db.sh and reload_partial.sh scripts try and run a fixup_${PROJ}.sh script without checking if it exists, this change skips that if it is missing.

This makes it easier to get started with smatch for a generic project which has no need to (at first at least) alter the DB.