### PR TITLE
Use --full-path for warnings/errors for generic projects

### DIFF
--- a/smatch_scripts/build_generic_data.sh
+++ b/smatch_scripts/build_generic_data.sh
@@ -62,7 +62,7 @@ if [[ ! -z $O ]] ; then
 	KERNEL_O="O=$O"
 fi
 
-make $KERNEL_ARCH $KERNEL_CROSS_COMPILE $KERNEL_O -j${NR_CPU} CC=$BIN_DIR/cgcc CHECK="$BIN_DIR/smatch --call-tree --info --spammy --file-output" $TARGET
+make $KERNEL_ARCH $KERNEL_CROSS_COMPILE $KERNEL_O -j${NR_CPU} CC=$BIN_DIR/cgcc CHECK="$BIN_DIR/smatch --call-tree --info --spammy --full-path --file-output" $TARGET
 
 find -name \*.c.smatch -exec cat \{\} \; -exec rm \{\} \; > smatch_warns.txt
 

--- a/smatch_scripts/test_generic.sh
+++ b/smatch_scripts/test_generic.sh
@@ -72,7 +72,7 @@ fi
 
 make $KERNEL_ARCH $KERNEL_CROSS_COMPILE $KERNEL_O clean
 find -name \*.c.smatch -exec rm \{\} \;
-make $KERNEL_ARCH $KERNEL_CROSS_COMPILE $KERNEL_O -j${NR_CPU} $ENDIAN -k CC=$BIN_DIR/cgcc CHECK="$CMD -p=${PROJECT} --file-output $*" \
+make $KERNEL_ARCH $KERNEL_CROSS_COMPILE $KERNEL_O -j${NR_CPU} $ENDIAN -k CC=$BIN_DIR/cgcc CHECK="$CMD -p=${PROJECT} --full-path --file-output $*" \
 	C=1 $TARGET 2>&1 | tee $LOG
 find -name \*.c.smatch -exec cat \{\} \; -exec rm \{\} \; > $WLOG
 


### PR DESCRIPTION
Many code bases have source files in different directories with the same name, for instance Slurm 24.11.5 has:
```
./src/common/env.c
./src/scrontab/env.c
```
This commit adds the `--full-path` option to scripts for building and testing generic projects so warnings and errors are unambiguously tied back to their source. This also reflects the description on using it for generic projects given in https://smatch.sourceforge.net/