### PR TITLE
Prevent Perl errors building DBs for generic projects

### DIFF
--- a/smatch_data/db/init_constraints.pl
+++ b/smatch_data/db/init_constraints.pl
@@ -50,26 +50,30 @@ sub load_manual_constraints($$)
         return;
     }
 
-    open(FILE, "$dir/$project.constraints");
-    while (<FILE>) {
-        s/\n//;
-        $db->do("insert or ignore into constraints (str) values ('$_')");
+    if (open(FILE, "$dir/$project.constraints"))
+    {
+        while (<FILE>) {
+            s/\n//;
+            $db->do("insert or ignore into constraints (str) values ('$_')");
+        }
+        close(FILE);
     }
-    close(FILE);
 
-    open(FILE, "$dir/$project.constraints_required");
-    while (<FILE>) {
-        my $limit;
-        my $dummy;
+    if (open(FILE, "$dir/$project.constraints_required"))
+    {
+        while (<FILE>) {
+            my $limit;
+            my $dummy;
 
-        ($dummy, $dummy, $limit) = split(/,/);
-        $limit =~ s/^ +//;
-        $limit =~ s/\n//;
-        try {
-            $db->do("insert or ignore into constraints (str) values ('$limit')");
-        } catch {}
+            ($dummy, $dummy, $limit) = split(/,/);
+            $limit =~ s/^ +//;
+            $limit =~ s/\n//;
+            try {
+                $db->do("insert or ignore into constraints (str) values ('$limit')");
+            } catch {}
+        }
+        close(FILE);
     }
-    close(FILE);
 
     $db->commit();
 }

--- a/smatch_data/db/init_constraints_required.pl
+++ b/smatch_data/db/init_constraints_required.pl
@@ -38,15 +38,17 @@ sub load_manual_constraints($$)
         return;
     }
 
-    open(FILE, "$dir/$project.constraints_required");
-    while (<FILE>) {
-        ($data, $op, $limit) = split(/,/);
-        $op =~ s/ //g;
-        $limit =~ s/^ +//;
-        $limit =~ s/\n//;
-        $db->do("insert into constraints_required values (?, ?, ?);", undef, $data, $op, $limit);
+    if(open(FILE, "$dir/$project.constraints_required"))
+    {
+        while (<FILE>) {
+            ($data, $op, $limit) = split(/,/);
+            $op =~ s/ //g;
+            $limit =~ s/^ +//;
+            $limit =~ s/\n//;
+            $db->do("insert into constraints_required values (?, ?, ?);", undef, $data, $op, $limit);
+        }
+        close(FILE);
     }
-    close(FILE);
 
     $db->commit();
 }

--- a/smatch_data/db/insert_manual_states.pl
+++ b/smatch_data/db/insert_manual_states.pl
@@ -64,38 +64,40 @@ sub insert_record($$$$$$$)
 
 my ($ret, $insert, $file, $func, $type, $param, $key, $value);
 
-open(FILE, "<$insertions");
-while (<FILE>) {
+if (open(FILE, "<$insertions"))
+{
+    while (<FILE>) {
 
-    if ($_ =~ /^\s*#/) {
-        next;
+        if ($_ =~ /^\s*#/) {
+            next;
+        }
+
+        ($ret, $insert) = split(/\|/, $_);
+
+        if ($ret =~ /(.+),\W*(.+),\W*"(.*)"/) {
+            $file = $1;
+            $func = $2;
+            $ret = $3;
+        } elsif ($ret =~ /(.+),\W*"(.*)"/) {
+            $file = "";
+            $func = $1;
+            $ret = $2;
+        } else {
+            next;
+        }
+
+        ($type, $param, $key, $value) = split(/,/, $insert);
+
+        $type = int($type);
+        $param = int($param);
+        $key =~ s/^["\s]+|["\s]+$//g;
+        $value =~ s/^["\s]+|["\s]+$//g;
+        chomp($value);
+
+        insert_record($file, $func, $ret, $type, $param, $key, $value);
     }
-
-    ($ret, $insert) = split(/\|/, $_);
-
-    if ($ret =~ /(.+),\W*(.+),\W*"(.*)"/) {
-        $file = $1;
-        $func = $2;
-        $ret = $3;
-    } elsif ($ret =~ /(.+),\W*"(.*)"/) {
-        $file = "";
-        $func = $1;
-        $ret = $2;
-    } else {
-        next;
-    }
-
-    ($type, $param, $key, $value) = split(/,/, $insert);
-
-    $type = int($type);
-    $param = int($param);
-    $key =~ s/^["\s]+|["\s]+$//g;
-    $value =~ s/^["\s]+|["\s]+$//g;
-    chomp($value);
-
-    insert_record($file, $func, $ret, $type, $param, $key, $value);
+    close(FILE);
 }
-close(FILE);
 
 $db->commit();
 $db->disconnect();


### PR DESCRIPTION
When running `build_generic_data.sh` I was getting errors like:
```
readline() on closed filehandle FILE at /path/to/smatch/smatch_scripts/../smatch_data/db/init_constraints.pl line 54.
readline() on closed filehandle FILE at /path/to/smatch/smatch_scripts/../smatch_data/db/init_constraints.pl line 61.
readline() on closed filehandle FILE at /path/to/smatch/smatch_scripts/../smatch_data/db/init_constraints_required.pl line 42.
off
off
readline() on closed filehandle FILE at /path/to/smatch/smatch_scripts/../smatch_data/db/insert_manual_states.pl line 68.
```
This is because the Perl scripts read from filehandles without checking if the open succeeded. These files don't exist for a new generic project so this commit changes the scripts to only try and read from them if their `open()` succeeds.