### PR TITLE
predefined_macros: define __illumos__ when built on illumos

### DIFF
--- a/predefine.c
+++ b/predefine.c
@@ -280,6 +280,9 @@ void predefined_macros(void)
 		predefine("__sun", 1, "1");
 		predefine_nostd("sun");
 		predefine("__svr4__", 1, "1");
+#ifdef __illumos__
+		predefine("__illumos__", 1, "1");
+#endif
 		break;
 	}
 }


### PR DESCRIPTION
The gcc used to build illumos does have __illumos__ defined, and while using smatch on illumos, it too should have __illumos__ defined.