### PR TITLE
smatch: support -W[no-]unused-label

### DIFF
--- a/options.c
+++ b/options.c
@@ -139,6 +139,7 @@ int Wuninitialized = 1;
 int Wunion_cast = 0;
 int Wuniversal_initializer = 0;
 int Wunknown_attribute = 0;
+int Wunused_label = 1;
 int Wvla = 1;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -897,6 +898,7 @@ static const struct flag warnings[] = {
 	{ "union-cast", &Wunion_cast },
 	{ "universal-initializer", &Wuniversal_initializer },
 	{ "unknown-attribute", &Wunknown_attribute },
+	{ "unused-label", &Wunused_label },
 	{ "vla", &Wvla },
 	{ }
 };

--- a/options.h
+++ b/options.h
@@ -139,6 +139,7 @@ extern int Wuninitialized;
 extern int Wunion_cast;
 extern int Wuniversal_initializer;
 extern int Wunknown_attribute;
+extern int Wunused_label;
 extern int Wvla;
 
 extern char **handle_switch(char *arg, char **next);

--- a/scope.c
+++ b/scope.c
@@ -32,6 +32,7 @@
 #include "allocate.h"
 #include "symbol.h"
 #include "scope.h"
+#include "options.h"
 
 static struct scope builtin_scope = { .next = &builtin_scope };
 
@@ -160,7 +161,9 @@ void end_label_scope(void)
 			continue;
 		if (sym->label_modifiers & MOD_UNUSED)
 			continue;
-		warning(sym->pos, "unused label '%s'", show_ident(sym->ident));
+		if (Wunused_label)
+			warning(sym->pos, "unused label '%s'",
+			    show_ident(sym->ident));
 	} END_FOR_EACH_PTR(sym);
 
 	end_scope(&label_scope);


### PR DESCRIPTION
Sometimes we would like to disable unused label warning.