### PR TITLE
build: fix VLA initialization for older compilers

### DIFF
--- a/pre-process.c
+++ b/pre-process.c
@@ -1649,7 +1649,8 @@ Econcat:
 static struct token *parse_expansion(struct token *expansion, struct ident *name)
 {
 	int slots = macro_nargs + (macro_vararg < 0);
-	struct arg_state args[slots] = {};
+	struct arg_state args[slots];
+	memset(args, 0, sizeof(args));
 	struct token **tail;
 	struct token *token;
 


### PR DESCRIPTION
Without this fix, compilation fails (for me) with:
```
  CC      pre-process.o
pre-process.c: In function ‘parse_expansion’:
pre-process.c:1648:16: error: variable-sized object may not be initialized
 1648 |         struct arg_state args[slots] = {};
      |                ^~~~~~~~~
make: *** [Makefile:447: pre-process.o]
```